### PR TITLE
Reduce paths to allow repo to be cloned. Add styles and stderr for clickable errors.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,12 @@ For more detailed information on installing the tool, see the
 `installation section <http://prospector.readthedocs.io/en/latest/#installation>`_ of the tool's main page
 on ReadTheDocs.
 
+If pip shows version conflicts (packages requiring older versions of other packages), some packages may need to be held back manually:
+
+    pip uninstall flake8 pep8-naming
+    pip install prospector2 flake8==3.5.0 pep8-naming==0.3.3
+
+
 Documentation
 -------------
 

--- a/prospector2/formatters/__init__.py
+++ b/prospector2/formatters/__init__.py
@@ -1,5 +1,16 @@
 # -*- coding: utf-8 -*-
-from prospector2.formatters import json, text, grouped, emacs, yaml, pylint, xunit, vscode
+from prospector2.formatters import (
+    json,
+    text,
+    grouped,
+    emacs,
+    yaml,
+    pylint,
+    xunit,
+    vscode,
+    pycodestyle,
+    pythonexception,
+)
 
 
 __all__ = (
@@ -13,7 +24,9 @@ FORMATTERS = {
     'grouped': grouped.GroupedFormatter,
     'emacs': emacs.EmacsFormatter,
     'yaml': yaml.YamlFormatter,
+    'pycodestyle': pycodestyle.PycodestyleFormatter,
     'pylint': pylint.PylintFormatter,
     'xunit': xunit.XunitFormatter,
     'vscode': vscode.VSCodeFormatter,
+    'pythonexception': pythonexception.PythonExceptionFormatter,
 }

--- a/prospector2/formatters/pycodestyle.py
+++ b/prospector2/formatters/pycodestyle.py
@@ -1,0 +1,34 @@
+from prospector2.formatters.base import Formatter
+
+
+__all__ = (
+    'PycodestyleFormatter',
+)
+
+
+class PycodestyleFormatter(Formatter):
+    """
+    Format messages the same way as Python's own exceptions to be
+    parseable (such as to navigate to the source line by double-clicking
+    the error in Geany and possibly other IDEs).
+    """
+
+    def render(self, summary=True, messages=True, profile=False):
+        # this formatter will always ignore the summary and profile
+        output = []
+        for message in sorted(self.messages):
+            #   ={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+            # prospector/configuration.py:65: [missing-docstring(missing-docstring), build_default_sources] \
+            # Missing function docstring
+            template = '%(path)s:%(line)s:%(col)s: [%(code)s(%(source)s), %(function)s] %(message)s'
+            output.append(template % {
+                'path': message.location.path,
+                'line': message.location.line,
+                'col': message.location.character if message.location.character else 0,
+                'source': message.source,
+                'code': message.code,
+                'function': message.location.function,
+                'message': message.message.strip()
+            })
+
+        return '\n'.join(output)

--- a/prospector2/formatters/pythonexception.py
+++ b/prospector2/formatters/pythonexception.py
@@ -1,0 +1,40 @@
+import re
+import os
+
+from prospector2.formatters.text import TextFormatter
+
+
+__all__ = (
+    'PythonExceptionFormatter',
+)
+
+
+class PythonExceptionFormatter(TextFormatter):
+    """
+    Format the location heading above each message the same way as
+    Python's own exceptions to be parseable (such as to navigate to the
+    source line by double-clicking the error in Geany and possibly
+    other IDEs).
+    """
+
+    def render_messages(self):
+        output = []
+        for message in sorted(self.messages):
+            # INFO: filename is the *linter* not the target here
+            line = message.location.line
+            fn_name = message.location.function
+            output.append('  File "%s", line %s, in %s'
+                          '' % (message.location.path, line, fn_name))
+            character = message.location.character
+            output.append(
+                '    %s: %s / %s%s' % (
+                    message.source,
+                    message.code,
+                    message.message,
+                    (' (col %s)' % character) if character else '',
+                )
+            )
+
+        output.append('')
+
+        return '\n'.join(output)

--- a/prospector2/run.py
+++ b/prospector2/run.py
@@ -131,7 +131,7 @@ class Prospector(object):
             self.summary['formatter'] = output_format
             formatter = FORMATTERS[output_format](self.summary, self.messages, self.config.profile)
             if not output_files:
-                self.write_to(formatter, sys.stdout)
+                self.write_to(formatter, sys.stderr)
             for output_file in output_files:
                 with open(output_file, 'w+') as target:
                     self.write_to(formatter, target)

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,32 @@ _INSTALL_REQUIRES = [
     'dodgy>=0.1.9',
     'pyyaml',
     'mccabe>=0.5.0',
-    'pyflakes<2.0.0,>=0.8.1',
-    'pycodestyle<2.4.0,>=2.0.0',
-    'pep8-naming>=0.3.3',
+    'pyflakes<2.4.0,>=0.8.1',
+    'pycodestyle<2.8.0,>=2.0.0',
+    'pep8-naming>=0.3.3,<=0.12.1',
     'pydocstyle>=2.0.0',
     'pylint<2',
+    'flake8==3.9.1',
 ]
+# ^ Later versions of flake8 cause:
+# flake8 3.9.2 requires pycodestyle<2.8.0,>=2.7.0, but you'll have pycodestyle 2.3.1 which is incompatible.
+# flake8 3.9.2 requires pyflakes<2.4.0,>=2.3.0, but you'll have pyflakes 1.6.0 which is incompatible.
+# ^ flake8==3.5.0 causes:
+# pep8-naming 0.13.1 requires flake8>=3.9.1, but you'll have flake8 3.5.0 which is incompatible.
+# - 'pyflakes<2.0.0,>=0.8.1',
+#   'pycodestyle<2.7.0,>=2.0.0',
+#   - cause:
+#     flake8 3.9.1 requires pycodestyle<2.8.0,>=2.7.0, but you'll have pycodestyle 2.3.1 which is incompatible.
+#     flake8 3.9.1 requires pyflakes<2.4.0,>=2.3.0, but you'll have pyflakes 1.6.0 which is incompatible.
+#   - but unfortunately, 'pep8-naming>=0.13.1' has Python3-only inline formatting
+#     - 0.12.1 is last release (<0.13.0) with Python 2 support
+# Fix:
+# python2 -m pip uninstall --yes pycodestyle pyflakes pep8-naming flake8 prospector2
+# python2 -m pip uninstall --yes pylint-plugin-utils requirements-detector setoptconf dodgy pyyaml pydocstyle
+# cd prospector2
+# python2 -m pip install -e . # OR:
+# Require this:
+# prospector2 @ git+https://github.com/Poikilos/prospector2@master
 
 _PACKAGE_DATA = {
     'prospector2': [

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,10 @@ _INSTALL_REQUIRES = [
     'pep8-naming>=0.3.3,<=0.12.1',
     'pydocstyle>=2.0.0',
     'pylint<2',
-    'flake8==3.9.1',
+    'flake8==3.5.0',
 ]
-# ^ Later versions of flake8 cause:
+# ^ flake8 dropped Python 2 support (in 4.0.0? <https://flake8.pycqa.org/en/latest/release-notes/4.0.0.html>)
+# ^ versions of flake8>3.5.0 cause:
 # flake8 3.9.2 requires pycodestyle<2.8.0,>=2.7.0, but you'll have pycodestyle 2.3.1 which is incompatible.
 # flake8 3.9.2 requires pyflakes<2.4.0,>=2.3.0, but you'll have pyflakes 1.6.0 which is incompatible.
 # ^ flake8==3.5.0 causes:

--- a/tests/finder/test_file_finder.py
+++ b/tests/finder/test_file_finder.py
@@ -44,8 +44,17 @@ class TestVirtualenvDetection(TestCase):
         run in Windows to be meaningful, though it shouldn't fail in other
         operating systems.
         """
-        path = [os.path.dirname(__file__), 'testdata', 'venvs']
+        venvs_path = [os.path.dirname(__file__), 'testdata', 'venvs']
+        path = venvs_path
         path.extend(['long_path_not_a_venv'] * 14)
         path.append('long_path_not_a_venv_long_path_not_a_v')
         path = os.path.join(*path)
+        os.makedirs(path)
+        """
+        with open(os.path.join(path, "README.txt") as stream:
+            stream.write("This file is only here to ensure that the"
+                         " parent directory is present in Git checkout")
+            # ^ deleted since path>256 prevents Windows git checkout :/
+        """
         self.assertFalse(is_virtualenv(path))
+        shutil.rmtree(venvs_path)

--- a/tests/finder/testdata/venvs/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv_long_path_not_a_v/README.txt
+++ b/tests/finder/testdata/venvs/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv_long_path_not_a_v/README.txt
@@ -1,1 +1,0 @@
-This file is only here to ensure that the parent directory is present in Git checkouts


### PR DESCRIPTION
- Remove the too-long path that prevents cloning on Windows.
  - Generate the path during the test (and remove it after the test is complete) instead (this means the test is the same but the repo doesn't have to contain the invalid path).
- Also update readme to mitigate #4 (pending discussion of changing setup.py)